### PR TITLE
Add acts as taggable gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,3 +86,5 @@ gem "repost", "~> 0.4.1"
 gem "rest-client", "~> 2.1"
 
 gem "tailwindcss-rails", "~> 2.0"
+
+gem 'acts-as-taggable-on', '~> 9.0'

--- a/Gemfile
+++ b/Gemfile
@@ -87,4 +87,8 @@ gem "rest-client", "~> 2.1"
 
 gem "tailwindcss-rails", "~> 2.0"
 
+# Add tags attribute to model [https://github.com/mbleigh/acts-as-taggable-on]
 gem 'acts-as-taggable-on', '~> 9.0'
+
+# Generate fake data [https://github.com/faker-ruby/faker]
+gem 'faker'

--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,6 @@ gem 'acts-as-taggable-on', '~> 9.0'
 
 # Generate fake data [https://github.com/faker-ruby/faker]
 gem 'faker'
+
+# Pagination library [https://github.com/mislav/will_paginate]
+gem 'will_paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    acts-as-taggable-on (9.0.1)
+      activerecord (>= 6.0, < 7.1)
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     aes_key_wrap (1.1.0)
@@ -346,6 +348,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 9.0)
   bootsnap
   byebug (~> 11.1)
   capybara

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
+    faker (3.2.1)
+      i18n (>= 1.8.11, < 2)
     faraday (2.7.9)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -354,6 +356,7 @@ DEPENDENCIES
   capybara
   debug
   devise (~> 4.9)
+  faker
   image_processing (~> 1.2)
   importmap-rails
   jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,6 +340,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    will_paginate (4.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.8)
@@ -377,6 +378,7 @@ DEPENDENCIES
   tzinfo-data
   web-console
   webdrivers
+  will_paginate
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@ Things you may want to cover:
 * System dependencies
 
 * Configuration
+- run `bundle install` to install all the required gems
 
 * Database creation
+- run `rails db:migrate` to generate required tables
 
 * Database initialization
+- run `rails db:generate_mock_articles` to generate mock articles data in database
 
 * How to run the test suite
 
@@ -22,9 +25,7 @@ Things you may want to cover:
 * Deployment instructions
 
 * How to run the development server
-- run `bundle install` to install all the required gems
 - run `RAILS_ENV=development bundle exec rake assets:precompile` every time you make changes in `/assets`
-- run `rails db:migrate`
 - run `bin/dev` to start the development server
 
 * ...

--- a/app/assets/stylesheets/pagination.css
+++ b/app/assets/stylesheets/pagination.css
@@ -1,0 +1,64 @@
+.flickr_pagination {
+  text-align: center;
+  padding: 0.3em;
+  cursor: default; 
+}
+
+.flickr_pagination a, .flickr_pagination span, .flickr_pagination em {
+  padding: 0.2em 0.5em; 
+}
+
+.flickr_pagination .disabled {
+  color: #aaaaaa; 
+}
+
+.flickr_pagination .current {
+  font-style: normal;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  height: 2rem;
+  color: #3d78f5;
+  border: 1px solid #d1d5db;
+  background-color: #e5eafc;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+.flickr_pagination .current:hover, .flickr_pagination .current:focus {
+  background-color: #c3d3fa;
+  color: #2661f2;
+}
+
+.flickr_pagination a {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  height: 2rem;
+  line-height: 1.25rem;
+  color: #6b7280;
+  background-color: #ffffff;
+  border: 1px solid #d1d5db;
+  text-decoration: none;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+.flickr_pagination a:hover, .flickr_pagination a:focus {
+  border-color: #003366;
+  background: #0063dc;
+  color: white; 
+}
+
+.flickr_pagination .previous_page, .flickr_pagination .next_page {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  line-height: 1.25rem;
+  color: #6b7280;
+  background-color: #ffffff;
+  border-width: 1px;
+  border-color: #d1d5db;
+  border-radius: 0.375rem;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+.flickr_pagination .previous_page:hover, .flickr_pagination .next_page:hover {
+  background-color: #f3f4f6;
+  color: #4b5563;
+}

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -65,6 +65,6 @@ class ArticlesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def article_params
-      params.require(:article).permit(:title, :summary, :content, :price, :currency)
+      params.require(:article).permit(:title, :summary, :content, :price, :currency, :tag_list)
     end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,7 @@
+class CategoriesController < ApplicationController
+  def show
+    category_uri = params[:category_uri]
+    @category = CATEGORIES.find { |item| item[:uri] == category_uri }
+    puts @category
+  end
+end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -3,6 +3,6 @@ class CategoriesController < ApplicationController
     @category_id = params[:id]
     category = CATEGORIES.find { |item| item[:id] == @category_id }
 
-    @articles_by_category = Article.tagged_with(category[:name].downcase)
+    @articles_by_category = Article.tagged_with(category[:name].downcase).paginate(page: params[:page], per_page: 5)
   end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,8 +1,9 @@
 class CategoriesController < ApplicationController
   def show
-    @category_id = params[:id]
-    category = CATEGORIES.find { |item| item[:id] == @category_id }
+    category = CATEGORIES.find { |item| item[:id] == params[:id] }
+    @category_name = category[:name]
+    @category_id = category[:id]
 
-    @articles_by_category = Article.tagged_with(category[:name].downcase).paginate(page: params[:page], per_page: 5)
+    @articles_by_category = Article.tagged_with(@category_name.downcase).paginate(page: params[:page], per_page: 5)
   end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,7 +1,8 @@
 class CategoriesController < ApplicationController
   def show
-    @category_name = params[:category_name]
+    @category_id = params[:id]
+    category = CATEGORIES.find { |item| item[:id] == @category_id }
 
-    @articles_by_category = Article.tagged_with(@category_name.downcase)
+    @articles_by_category = Article.tagged_with(category[:name].downcase)
   end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,7 +1,7 @@
 class CategoriesController < ApplicationController
   def show
-    category_uri = params[:category_uri]
-    @category = CATEGORIES.find { |item| item[:uri] == category_uri }
-    puts @category
+    @category_name = params[:category_name]
+
+    @articles_by_category = Article.tagged_with(@category_name.downcase)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,2 @@
 module ApplicationHelper
-  def article_categories
-    [
-      { name: 'Economy', uri: 'economy' },
-      { name: 'Politics & Laws', uri: 'politics-and-laws' },
-      { name: 'Society', uri: 'society' },
-      { name: 'Sports', uri: 'sports' },
-      { name: 'Tech', uri: 'tech' },
-      { name: 'Health', uri: 'health' }
-    ]
-  end
 end

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,0 +1,2 @@
+module CategoriesHelper
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,5 @@
 class Article < ApplicationRecord
+  acts_as_taggable_on :tags
   has_rich_text :content
 
   has_many :transactions, as: :related_object

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -25,6 +25,11 @@
     <%= form.label :content, style: "display: block" %>
     <%= form.text_area :content %>
   </div>
+  
+  <div>
+    <%= form.label :tag_list, "Tags (separated by commas)", style: "display: block" %>
+    <%= form.text_field :tag_list %>
+  </div>
 
   <div>
     <%= form.label :price, style: "display: block" %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -29,8 +29,7 @@
 
               <div class="mb-2">
                 <span class="text-primary-700 font-semibold">Category:</span>
-                <% tag_list = article.tag_list.join(', ') %>
-                <span class="text-primary-700"><%= tag_list %></span>
+                <span class="text-primary-700"><%= article.tag_list.join(', ') %></span>
               </div>
 
               <a href="<%= article_path(article) %>" class="text-neutral-500">

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -27,6 +27,12 @@
                 </small>
               </p>
 
+              <div class="mb-2">
+                <span class="text-primary-700 font-semibold">Category:</span>
+                <% tag_list = article.tag_list.join(', ') %>
+                <span class="text-primary-700"><%= tag_list %></span>
+              </div>
+
               <a href="<%= article_path(article) %>" class="text-neutral-500">
                 <%= article.summary.truncate_words(50) %>
 

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,11 +1,10 @@
-
 <div class="container mx-auto md:px-6">
   <div class="grid grid-cols-3 gap-4">
     <div class="col-span-2">
       <!-- Section: Design Block -->
       <section class="mb-32 text-center md:text-left">
 
-        <% @articles.each_with_index do |article, index| %>
+        <% @articles.first(5).each_with_index do |article, index| %>
           <div class="mb-12 grid items-center gap-x-6 md:grid-cols-2 xl:gap-x-12">
             <div class="mb-6 md:mb-0 <%= "md:order-2" if index.odd? %>">
               <div class="relative mb-6 overflow-hidden rounded-lg bg-cover bg-no-repeat shadow-lg"
@@ -196,9 +195,9 @@
   </div>
 
 
-
-    <!-- Section: Design Block -->
-  <section class="mb-32 text-center">
+  <%
+=begin%>
+ <section class="mb-32 text-center">
     <h2 class="mb-12 text-center text-3xl font-bold">Latest articles</h2>
 
     <div class="grid gap-6 lg:grid-cols-3 xl:gap-x-12">
@@ -297,8 +296,9 @@
         </div>
       </div>
     </div>
-  </section>
-  <!-- Section: Design Block -->
+  </section> 
+<%
+=end%>
 </div>
 
 

--- a/app/views/categories/_group.html.erb
+++ b/app/views/categories/_group.html.erb
@@ -9,7 +9,7 @@
     <% if !articles.present? %>
       No articles found.
     <% else %>
-      <% articles.first(6).each do |article| %>
+      <% articles.each do |article| %>
         <li class="py-6">
           <div class="flex flex-row items-center 2xl:space-y-0">
             <div class="w-2/5">
@@ -50,11 +50,3 @@
     <% end %>
   </ul>
 </div>
-
-<% if articles.length > 6 %>
-  <div class="flex justify-start text-base font-medium leading-6">
-    <a href="<%= articles_path %>" class="text-primary-500 hover:text-primary-600">
-      Read more &rarr;
-    </a>
-  </div>
-<% end %>

--- a/app/views/categories/_group.html.erb
+++ b/app/views/categories/_group.html.erb
@@ -1,0 +1,60 @@
+<div class="divide-y divide-gray-200 ">
+  <div class="space-y-2 pb-6 ml-6 md:space-y-5">
+    <h1 class="text-3xl font-extrabold leading-9 tracking-tight text-primary-600 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
+      Latest
+    </h1>
+  </div>
+  
+  <ul class="divide-y divide-gray-200">
+    <% if !articles.present? %>
+      No articles found.
+    <% else %>
+      <% articles.first(6).each do |article| %>
+        <li class="py-6">
+          <div class="flex flex-row items-center 2xl:space-y-0">
+            <div class="w-2/5">
+              <div class="aspect-w-5 aspect-h-3">
+                <img src="https://mdbcdn.b-cdn.net/img/new/standard/city/018.jpg" class="w-full h-full object-cover px-4" alt="Louvre" />
+              </div>
+            </div>
+
+            <div class="w-3/5 space-y-5 col-span-3">
+              <div class="space-y-6">
+                <div>
+                  <h2 class="text-2xl font-bold leading-8 tracking-tight">
+                    <a href=<%= article_path(article) %> class="text-gray-900 ">
+                      <%= article.title %>
+                    </a>
+                  </h2>
+                  <div class="text-base font-medium leading-6 text-gray-500">
+                    21 August, 2023
+                  </div>
+                </div>
+
+                <div class="prose max-w-none text-gray-500">
+                  <%= truncate(article.summary, length: 160) %>
+                </div>
+
+              </div>
+
+              <div class="text-base font-medium leading-6">
+                <a href=<%= article_path(article) %> class="text-primary-500 hover:text-primary-600">
+                  Read more &rarr;
+                </a>
+              </div>
+
+            </div>
+          </div>
+        </li>
+      <% end %>
+    <% end %>
+  </ul>
+</div>
+
+<% if articles.length > 6 %>
+  <div class="flex justify-end text-base font-medium leading-6">
+    <a href="<%= articles_path %>" class="text-primary-500 hover:text-primary-600">
+      All Articles &rarr;
+    </a>
+  </div>
+<% end %>

--- a/app/views/categories/_group.html.erb
+++ b/app/views/categories/_group.html.erb
@@ -1,6 +1,6 @@
 <div class="divide-y divide-gray-200 ">
-  <div class="space-y-2 pb-6 ml-6 md:space-y-5">
-    <h1 class="text-3xl font-extrabold leading-9 tracking-tight text-primary-600 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
+  <div class="pb-6 ml-6">
+    <h1 class="text-3xl font-extrabold leading-9 tracking-tight text-primary-600">
       Latest
     </h1>
   </div>
@@ -52,9 +52,9 @@
 </div>
 
 <% if articles.length > 6 %>
-  <div class="flex justify-end text-base font-medium leading-6">
+  <div class="flex justify-start text-base font-medium leading-6">
     <a href="<%= articles_path %>" class="text-primary-500 hover:text-primary-600">
-      All Articles &rarr;
+      Read more &rarr;
     </a>
   </div>
 <% end %>

--- a/app/views/categories/_group.html.erb
+++ b/app/views/categories/_group.html.erb
@@ -1,4 +1,4 @@
-<div class="divide-y divide-gray-200 ">
+<div class="divide-y divide-gray-200">
   <div class="pb-6 ml-6">
     <h1 class="text-3xl font-extrabold leading-9 tracking-tight text-primary-600">
       Latest

--- a/app/views/categories/_hero.html.erb
+++ b/app/views/categories/_hero.html.erb
@@ -1,0 +1,41 @@
+<div class="mb-12 w-full">
+  <div class="text-center">
+    <h1 class="text-4xl font-semibold text-gray-900 mb-4 uppercase"><%= hero_title %></h1>
+    <p class="text-gray-600 text-lg mb-8 w-1/2 mx-auto">
+      News and updates from the <%= hero_title.downcase %> team. Topics include genetics, infectious disease, psychology, and more.
+    </p>
+    <div class="w-3/4 h-1 bg-primary-500 mx-auto mb-10"></div>
+  </div>
+
+  <div class="flex gap-0.5">
+    <div class="w-3/5">
+      <div class="relative h-full">
+        <img src="https://mdbcdn.b-cdn.net/img/new/standard/city/018.jpg" class="w-full h-full object-cover" alt="Image 1" />
+        <div class="absolute inset-0 bg-black/75 w-3/4 h-fit flex flex-col text-center items-center p-4 m-auto text-slate-200">
+          <h2 class="text-3xl font-semibold mb-2">What we know about the wildfires in Hawaii</h2>
+          <p class="text-center text-normal">By Author Name</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="w-2/5 flex flex-col justify-between gap-0.5">
+      <div class="relative">
+        <img src="https://mdbcdn.b-cdn.net/img/new/standard/city/018.jpg" class="w-full object-cover" alt="Image 2" />
+        <div class="absolute inset-0 bg-black/75 w-3/4 h-fit flex flex-col text-center items-center p-4 m-auto text-slate-200">
+          <h2 class="font-semibold mb-2 text-lg">What we know about the wildfires in Hawaii</h2>
+          <p class="text-center text-normal">By Author Name</p>
+        </div>
+      </div>
+      
+      <div class="relative">
+        <img src="https://mdbcdn.b-cdn.net/img/new/standard/city/018.jpg" class="w-full object-cover" alt="Image 2" />
+        <div class="absolute inset-0 bg-black/75 w-3/4 h-fit flex flex-col text-center items-center p-4 m-auto text-slate-200">
+          <h2 class="font-semibold mb-2 text-lg">What we know about the wildfires in Hawaii</h2>
+          <p class="text-center text-normal">By Author Name</p>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+</div>

--- a/app/views/categories/_pagination.html.erb
+++ b/app/views/categories/_pagination.html.erb
@@ -1,0 +1,3 @@
+<div class="flickr_pagination">
+  <%= will_paginate @articles_by_category, :container => true %>
+</div>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,0 +1,1 @@
+<h1><%= @category[:name] %> Category</h1>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,52 +1,8 @@
-<h1><%= @category_name %> Category</h1>
-
-
 <div class="container mx-auto md:px-6">
   <div class="grid grid-cols-3 gap-4">
     <div class="col-span-2">
-      <!-- Section: Design Block -->
-      <section class="mb-32 text-center md:text-left">
-
-        <% @articles_by_category.each_with_index do |article, index| %>
-          <div class="mb-12 grid items-center gap-x-6 md:grid-cols-2 xl:gap-x-12">
-            <div class="mb-6 md:mb-0 <%= "md:order-2" if index.odd? %>">
-              <div class="relative mb-6 overflow-hidden rounded-lg bg-cover bg-no-repeat shadow-lg"
-                data-te-ripple-init data-te-ripple-color="light">
-                <img src="https://mdbcdn.b-cdn.net/img/new/standard/city/018.jpg" class="w-full" alt="Louvre" />
-                <a href="<%= article_path(article) %>">
-                  <div
-                    class="absolute top-0 right-0 bottom-0 left-0 h-full w-full overflow-hidden bg-fixed opacity-0 transition duration-300 ease-in-out hover:opacity-100 bg-[hsla(0,0%,98.4%,.15)]">
-                  </div>
-                </a>
-              </div>
-            </div>
-
-            <div class=" <%= "md:order-1" if index.odd? %>">
-              <a href="<%= article_path(article) %>" class="h3 mb-3 text-2xl font-bold"><%= article.title %></a>
-
-              <p class="mb-6 text-neutral-500">
-                <small>Published <u><%= article.created_at.strftime("%b %d, %Y") %></u>
-                </small>
-              </p>
-
-              <div class="mb-2">
-                <span class="text-primary-700 font-semibold">Category:</span>
-                <span class="text-primary-700"><%= article.tag_list.join(', ') %></span>
-              </div>
-
-              <a href="<%= article_path(article) %>" class="text-neutral-500">
-                <%= article.summary.truncate_words(50) %>
-
-                <span class="text-sm text-orange-500"> see more </span>
-              </a>
-            </div>
-          </div>
-        <% end %>
-
-      </section>
-      <!-- Section: Design Block -->
+      <%= render "categories/group", articles: @articles_by_category %>
     </div>
   </div>
 </div>
-
 

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -2,6 +2,8 @@
   <div class="grid grid-cols-3 gap-4">
     <div class="col-span-2">
       <%= render "categories/group", articles: @articles_by_category %>
+
+      <%= render "categories/pagination" %>
     </div>
   </div>
 </div>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,1 +1,53 @@
-<h1><%= @category[:name] %> Category</h1>
+<h1><%= @category_name %> Category</h1>
+
+
+<div class="container mx-auto md:px-6">
+  <div class="grid grid-cols-3 gap-4">
+    <div class="col-span-2">
+      <!-- Section: Design Block -->
+      <section class="mb-32 text-center md:text-left">
+
+        <% @articles_by_category.each_with_index do |article, index| %>
+          <div class="mb-12 grid items-center gap-x-6 md:grid-cols-2 xl:gap-x-12">
+            <div class="mb-6 md:mb-0 <%= "md:order-2" if index.odd? %>">
+              <div class="relative mb-6 overflow-hidden rounded-lg bg-cover bg-no-repeat shadow-lg"
+                data-te-ripple-init data-te-ripple-color="light">
+                <img src="https://mdbcdn.b-cdn.net/img/new/standard/city/018.jpg" class="w-full" alt="Louvre" />
+                <a href="<%= article_path(article) %>">
+                  <div
+                    class="absolute top-0 right-0 bottom-0 left-0 h-full w-full overflow-hidden bg-fixed opacity-0 transition duration-300 ease-in-out hover:opacity-100 bg-[hsla(0,0%,98.4%,.15)]">
+                  </div>
+                </a>
+              </div>
+            </div>
+
+            <div class=" <%= "md:order-1" if index.odd? %>">
+              <a href="<%= article_path(article) %>" class="h3 mb-3 text-2xl font-bold"><%= article.title %></a>
+
+              <p class="mb-6 text-neutral-500">
+                <small>Published <u><%= article.created_at.strftime("%b %d, %Y") %></u>
+                </small>
+              </p>
+
+              <div class="mb-2">
+                <span class="text-primary-700 font-semibold">Category:</span>
+                <% tag_list = article.tag_list.join(', ') %>
+                <span class="text-primary-700"><%= tag_list %></span>
+              </div>
+
+              <a href="<%= article_path(article) %>" class="text-neutral-500">
+                <%= article.summary.truncate_words(50) %>
+
+                <span class="text-sm text-orange-500"> see more </span>
+              </a>
+            </div>
+          </div>
+        <% end %>
+
+      </section>
+      <!-- Section: Design Block -->
+    </div>
+  </div>
+</div>
+
+

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,10 +1,16 @@
-<div class="container mx-auto md:px-6">
-  <div class="grid grid-cols-3 gap-4">
-    <div class="col-span-2">
-      <%= render "categories/group", articles: @articles_by_category %>
+<div>
+  <%= render "categories/hero", hero_title: @category_name %>
+  
+  <div class="container mx-auto">
 
-      <%= render "categories/pagination" %>
+    <div class="grid grid-cols-3 gap-4">
+      <div class="col-span-2">
+        <%= render "categories/group", articles: @articles_by_category %>
+
+        <%= render "categories/pagination" %>
+      </div>
     </div>
   </div>
 </div>
+
 

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -31,8 +31,7 @@
 
               <div class="mb-2">
                 <span class="text-primary-700 font-semibold">Category:</span>
-                <% tag_list = article.tag_list.join(', ') %>
-                <span class="text-primary-700"><%= tag_list %></span>
+                <span class="text-primary-700"><%= article.tag_list.join(', ') %></span>
               </div>
 
               <a href="<%= article_path(article) %>" class="text-neutral-500">

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -13,7 +13,7 @@
           <ul class="text-gray-500 font-medium">
             <% CATEGORIES.each do |category| %>
               <li class="mb-4">
-                <a href="<%= category[:uri] %>" class="hover:underline"><%= category[:name] %></a>
+                <a href="/categories/<%= category[:id] %>" class="hover:underline"><%= category[:name] %></a>
               </li>
             <% end %>
           </ul>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -11,7 +11,7 @@
         <div>
           <h2 class="mb-6 text-sm font-semibold text-gray-900 uppercase">Categories</h2>
           <ul class="text-gray-500 font-medium">
-            <% article_categories.each do |category| %>
+            <% CATEGORIES.each do |category| %>
               <li class="mb-4">
                 <a href="<%= category[:uri] %>" class="hover:underline"><%= category[:name] %></a>
               </li>

--- a/app/views/layouts/_topnav.html.erb
+++ b/app/views/layouts/_topnav.html.erb
@@ -54,10 +54,10 @@
         <ul class="flex flex-col font-medium p-4 md:p-0 mt-4 border border-gray-100 rounded-lg bg-gray-50 md:flex-row md:space-x-8 md:mt-0 md:border-0 md:bg-white">
           <% CATEGORIES.each do |category| %>
             <li>
-              <% if @category_name && category[:name] == @category_name %>
-                <a href="/<%= category[:uri] %>" class="block py-2 pl-3 pr-4 text-white bg-blue-700 rounded bg-transparent md:text-blue-700 md:p-0"><%= category[:name] %></a>
+              <% if @category_id && category[:id] == @category_id %>
+                <a href="/categories/<%= category[:id] %>" class="block py-2 pl-3 pr-4 text-white bg-blue-700 rounded bg-transparent md:text-blue-700 md:p-0"><%= category[:name] %></a>
               <% else %>
-                <a href="/<%= category[:uri] %>" class="block py-2 pl-3 pr-4 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:hover:text-primary-700 md:p-0"><%= category[:name] %></a>
+                <a href="/categories/<%= category[:id] %>" class="block py-2 pl-3 pr-4 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:hover:text-primary-700 md:p-0"><%= category[:name] %></a>
               <% end %>
             </li>
           <% end %>

--- a/app/views/layouts/_topnav.html.erb
+++ b/app/views/layouts/_topnav.html.erb
@@ -54,7 +54,7 @@
         <ul class="flex flex-col font-medium p-4 md:p-0 mt-4 border border-gray-100 rounded-lg bg-gray-50 md:flex-row md:space-x-8 md:mt-0 md:border-0 md:bg-white">
           <% CATEGORIES.each do |category| %>
             <li>
-              <% if @category && category[:uri] == @category[:uri] %>
+              <% if @category_name && category[:name] == @category_name %>
                 <a href="/<%= category[:uri] %>" class="block py-2 pl-3 pr-4 text-white bg-blue-700 rounded bg-transparent md:text-blue-700 md:p-0"><%= category[:name] %></a>
               <% else %>
                 <a href="/<%= category[:uri] %>" class="block py-2 pl-3 pr-4 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:hover:text-primary-700 md:p-0"><%= category[:name] %></a>

--- a/app/views/layouts/_topnav.html.erb
+++ b/app/views/layouts/_topnav.html.erb
@@ -52,14 +52,14 @@
 
       <div class="items-center justify-between hidden w-full md:flex md:w-auto md:order-1" id="navbar-user">
         <ul class="flex flex-col font-medium p-4 md:p-0 mt-4 border border-gray-100 rounded-lg bg-gray-50 md:flex-row md:space-x-8 md:mt-0 md:border-0 md:bg-white">
-          <li>
-            <a href="/" class="block py-2 pl-3 pr-4 text-white bg-blue-700 rounded md:bg-transparent md:text-blue-700 md:p-0" aria-current="page">Home</a>
-          </li>
-
-          <% article_categories.each do |category| %>
+          <% CATEGORIES.each do |category| %>
             <li>
-            <a href="/<%= category[:uri] %>" class="block py-2 pl-3 pr-4 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:hover:text-primary-700 md:p-0"><%= category[:name] %></a>
-          </li>
+              <% if @category && category[:uri] == @category[:uri] %>
+                <a href="/<%= category[:uri] %>" class="block py-2 pl-3 pr-4 text-white bg-blue-700 rounded bg-transparent md:text-blue-700 md:p-0"><%= category[:name] %></a>
+              <% else %>
+                <a href="/<%= category[:uri] %>" class="block py-2 pl-3 pr-4 text-gray-900 rounded hover:bg-gray-100 md:hover:bg-transparent md:hover:text-primary-700 md:p-0"><%= category[:name] %></a>
+              <% end %>
+            </li>
           <% end %>
         </ul>
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
         <%= render "layouts/topnav" %>
       <% end %>
     
-      <main class="container mx-auto mt-28 px-5 flex grow">
+      <main class="container mx-auto mt-28 flex grow">
         <p style="color: green"><%= notice %></p>
         <%= yield %>
       </main>

--- a/app/views/subscriptions/_daily_pricing.html.erb
+++ b/app/views/subscriptions/_daily_pricing.html.erb
@@ -4,11 +4,11 @@
         <div class="flex flex-col p-6 mx-auto max-w-lg text-center text-gray-900 bg-white rounded-lg border border-gray-100 shadow xl:p-8 h-fit">
             <h3 class="mb-4 text-2xl font-semibold">Pay per Article</h3>
             <p class="font-light text-gray-500 sm:text-lg">Bill at the end of the month.</p>
-            <div class="flex justify-center items-baseline my-8">
+            <div class="flex justify-center items-baseline mt-8 mb-4">
                 <span class="mr-2 text-5xl font-extrabold">$0.10</span>
                 <span class="text-gray-500">/basic article</span>
             </div>
-            <div class="flex justify-center items-baseline my-8">
+            <div class="flex justify-center items-baseline mb-8">
                 <span class="mr-2 text-5xl font-extrabold">$0.25</span>
                 <span class="text-gray-500">/sports article</span>
             </div>

--- a/config/categories.yml
+++ b/config/categories.yml
@@ -1,0 +1,13 @@
+page_categories:
+  - name: Economy
+    uri: economy
+  - name: Politics and Laws
+    uri: politics-and-laws
+  - name: Society
+    uri: society
+  - name: Sports
+    uri: sports
+  - name: Tech
+    uri: tech
+  - name: Health
+    uri: health

--- a/config/categories.yml
+++ b/config/categories.yml
@@ -1,13 +1,13 @@
 page_categories:
   - name: Economy
-    uri: economy
+    id: economy
   - name: Politics and Laws
-    uri: politics-and-laws
+    id: politics-and-laws
   - name: Society
-    uri: society
+    id: society
   - name: Sports
-    uri: sports
+    id: sports
   - name: Tech
-    uri: tech
+    id: tech
   - name: Health
-    uri: health
+    id: health

--- a/config/initializers/categories.rb
+++ b/config/initializers/categories.rb
@@ -1,0 +1,10 @@
+# config_for is not working
+# CATEGORIES_CONFIG = Rails.application.config_for(:categories)
+CATEGORIES_CONFIG = YAML.load_file("config/categories.yml")
+
+CATEGORIES = CATEGORIES_CONFIG["page_categories"].map do |category|
+    {
+      name: category["name"],
+      uri: category["uri"]
+    }
+  end

--- a/config/initializers/categories.rb
+++ b/config/initializers/categories.rb
@@ -5,6 +5,6 @@ CATEGORIES_CONFIG = YAML.load_file("config/categories.yml")
 CATEGORIES = CATEGORIES_CONFIG["page_categories"].map do |category|
     {
       name: category["name"],
-      uri: category["uri"]
+      id: category["id"]
     }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,7 @@ Rails.application.routes.draw do
 
   # should authenticate with admin_user instead
 
-  CATEGORIES.each do |category|
-    get "/#{category[:uri]}", to: "categories#show", category_name: category[:name]
-  end
+  get "/categories/:id", to: "categories#show"
 
   get "/subscriptions", to: "subscriptions#index"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,12 @@
 Rails.application.routes.draw do
-  get 'subscriptions/show'
   devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # should authenticate with admin_user instead
 
-  # TODO: change this later
-  get "/economy", to: "articles#index"
-  get "/politics-and-laws", to: "articles#index"
-  get "/society", to: "articles#index"
-  get "/sports", to: "articles#index"
-  get "/tech", to: "articles#index"
-  get "/health", to: "articles#index"
+  CATEGORIES.each do |category|
+    get "/#{category[:uri]}", to: "categories#show", category_uri: category[:uri]
+  end
 
   get "/subscriptions", to: "subscriptions#index"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   # should authenticate with admin_user instead
 
   CATEGORIES.each do |category|
-    get "/#{category[:uri]}", to: "categories#show", category_uri: category[:uri]
+    get "/#{category[:uri]}", to: "categories#show", category_name: category[:name]
   end
 
   get "/subscriptions", to: "subscriptions#index"

--- a/db/migrate/20230817031206_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230817031206_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+class ActsAsTaggableOnMigration < ActiveRecord::Migration[6.0]
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20230817031206_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230817031206_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -13,8 +13,8 @@ class ActsAsTaggableOnMigration < ActiveRecord::Migration[6.0]
 
       # You should make sure that the column created is
       # long enough to store the required class names.
-      t.references :taggable, polymorphic: true
-      t.references :tagger, polymorphic: true
+      t.references :taggable, polymorphic: true, type: :uuid
+      t.references :tagger, polymorphic: true, type: :uuid
 
       # Limit is created to prevent MySQL error on index
       # length for MyISAM table type: http://bit.ly/vgW2Ql

--- a/db/migrate/20230817031207_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230817031207_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+class AddMissingUniqueIndices < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20230817031208_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230817031208_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20230817031209_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230817031209_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+class AddMissingTaggableIndex < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+              name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20230817031210_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230817031210_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+
+class ChangeCollationForTagNames < ActiveRecord::Migration[6.0]
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20230817031211_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230817031211_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+class AddMissingIndexesOnTaggings < ActiveRecord::Migration[6.0]
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                 :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                                   :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table,
+                                                                               :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                         name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
+                name: 'taggings_idy'
+    end
+  end
+end

--- a/db/migrate/20230817031212_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20230817031212_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from acts_as_taggable_on_engine (originally 7)
+class AddTenantToTaggings < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.taggings_table, :tenant, :string, limit: 128
+    add_index ActsAsTaggableOn.taggings_table, :tenant unless index_exists? ActsAsTaggableOn.taggings_table, :tenant
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, :tenant
+    remove_column ActsAsTaggableOn.taggings_table, :tenant
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_07_114511) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_17_031212) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -276,6 +276,37 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_07_114511) do
     t.index ["name"], name: "motor_tags_name_unique_index", unique: true
   end
 
+  create_table "taggings", force: :cascade do |t|
+    t.bigint "tag_id"
+    t.string "taggable_type"
+    t.bigint "taggable_id"
+    t.string "tagger_type"
+    t.bigint "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at", precision: nil
+    t.string "tenant", limit: 128
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+    t.index ["tagger_type", "tagger_id"], name: "index_taggings_on_tagger_type_and_tagger_id"
+    t.index ["tenant"], name: "index_taggings_on_tenant"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   create_table "transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "user_id", null: false
     t.string "provider"
@@ -331,6 +362,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_07_114511) do
   add_foreign_key "motor_note_tag_tags", "motor_note_tags", column: "tag_id"
   add_foreign_key "motor_note_tag_tags", "motor_notes", column: "note_id"
   add_foreign_key "motor_taggable_tags", "motor_tags", column: "tag_id"
+  add_foreign_key "taggings", "tags"
   add_foreign_key "transactions", "credit_tokens"
   add_foreign_key "transactions", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -279,9 +279,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_17_031212) do
   create_table "taggings", force: :cascade do |t|
     t.bigint "tag_id"
     t.string "taggable_type"
-    t.bigint "taggable_id"
+    t.uuid "taggable_id"
     t.string "tagger_type"
-    t.bigint "tagger_id"
+    t.uuid "tagger_id"
     t.string "context", limit: 128
     t.datetime "created_at", precision: nil
     t.string "tenant", limit: 128

--- a/lib/tasks/generate_mock_articles.rake
+++ b/lib/tasks/generate_mock_articles.rake
@@ -1,0 +1,38 @@
+namespace :db do
+  desc "Generate mock articles data"
+  task generate_mock_articles: :environment do
+    # Clear existing data
+    Article.delete_all
+    ActsAsTaggableOn::Tagging.delete_all    
+
+    # Create mock articles with associated tags
+    CATEGORIES.each do |category|
+      10.times do
+        article = Article.create(
+          title: Faker::Lorem.sentence,
+          summary: Faker::Lorem.sentence(word_count: rand(20..40)),
+          content: generate_long_paragraphs(rand(5..10)),
+          price: rand(1.0..100.0).round(2),
+          currency: "USD"
+        )
+        
+        # One article has multiple tags
+        # tags = CATEGORIES.map { |category| ActsAsTaggableOn::Tag.create(name: category[:name]) }
+        # random_tags = tags.select { |tag| tag.name != category[:name] }.sample(rand(1..3))
+        # article.tag_list.add(random_tags.pluck(:name))
+
+        # One article has one tag
+        article.tag_list.add(category[:name])
+        article.save
+      end
+    end
+  end
+
+  def generate_long_paragraphs(paragraph_count)
+    paragraphs = []
+    paragraph_count.times do
+      paragraphs << Faker::Lorem.paragraph(sentence_count: rand(2..20))
+    end
+    paragraphs.join("\n\n")
+  end
+end

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CategoriesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What 
* Add `acts_as_taggable` to Articles to manage tags for page category
* Create constant `CATEGORIES` for page categories
* Add `will_paginate` gem to manage pagination
* Implement UI for category page
* Set up tasks to create mock articles to database  

# Why
- We need to browse categories for more dynamic website

# Demo
Economy page:
<img width="1440" alt="image" src="https://github.com/Pressingly/oidc-ecommerce-test-site/assets/69509154/6ed72560-ba0b-4b8c-b4d5-7e85cc810b9e">

<img width="1440" alt="image" src="https://github.com/Pressingly/oidc-ecommerce-test-site/assets/69509154/6eade2fc-64e3-4e79-9976-b03a97202d01">

Pagination function - shows 5 latest articles per page:
<img width="1436" alt="image" src="https://github.com/Pressingly/oidc-ecommerce-test-site/assets/69509154/e24dce16-53fe-445d-b95e-7130e2fb95e4">


# Refs
Gems:
* https://github.com/mbleigh/acts-as-taggable-on
* [UUID issue with the tag](https://github.com/mbleigh/acts-as-taggable-on/issues/698)
* https://github.com/faker-ruby/faker
* https://mislav.github.io/will_paginate/

UI template:
* https://www.tailwindawesome.com/resources/tailwind-nextjs-starter-blog